### PR TITLE
Add cookie policy notice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,25 @@ import '../static/css/imagemapchart.css';
 import jQuery from 'jquery';
 import module from 'imagemapchart/src/index.js';
 
+var getUrlParameter = function getUrlParameter(sParam) {
+    var sPageURL = decodeURIComponent(window.location.search.substring(1));
+    var sURLVariables = sPageURL.split('&');
+
+    for (var i = 0; i < sURLVariables.length; i++) {
+        var sParameterName = sURLVariables[i].split('=');
+
+        if (sParameterName[0] === sParam) {
+            return sParameterName[1] === undefined ? true : sParameterName[1];
+        }
+    }
+};
+
 jQuery(document).ready(function() {
+
+    if (!getUrlParameter('parent')) {
+        jQuery('#cu-privacy-notice').addClass('required');
+    }
+
     module.ImageMapChartApp.initialize({
         el: jQuery('.infographic'),
         template: require('../static/templates/page.html'),

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -108,3 +108,6 @@ footer {
 .form-group.has-error .error-block {
     display: block;
 }
+
+#cu-privacy-notice { display: none; }
+#cu-privacy-notice.required { display: block; }

--- a/static/index.html
+++ b/static/index.html
@@ -24,6 +24,9 @@
         }
         </script>
 
+        <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+        <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+
     </head>
     <body itemscope itemtype="http://schema.org/WebPage">
     <div class="interactive-container" style="display: none;">


### PR DESCRIPTION
Initial policy display can be toggled based on a url parameter. When an interactive is displayed in a larger context, setting the parent parameter to any value will hide the notice.